### PR TITLE
Fix folding of c-preproc-if

### DIFF
--- a/ts-fold.el
+++ b/ts-fold.el
@@ -446,7 +446,8 @@ more information."
 For arguments NODE and OFFSET, see function `ts-fold-range-seq' for
 more information."
   (let* ((named-node (treesit-node-child-by-field-name node "condition"))
-         (else (treesit-node-child-by-field-name node "alternative"))
+         (else (or (treesit-node-child-by-field-name node "alternative")
+                   (treesit-node-child node -1)))
          (beg (treesit-node-end named-node))
          (end (1- (treesit-node-start else))))
     (ts-fold--cons-add (cons beg end) offset)))


### PR DESCRIPTION
I just tried this ts-fold repo with treesit support and finded an issue.

Some c-preproc-if have no 'else' branch and 'alternative' node. For example:

CODE:
```c
 #if THREAD_SIZE >= PAGE_SIZE
 void __init __weak thread_stack_cache_init(void)
 {
 }
 #endif
```

treesit generated TREE:
```lisp
(preproc_if #if
 condition: (binary_expression left: (identifier) operator: >= right: (identifier))
 \n
 (declaration type: (primitive_type) declarator: (identifier) type: ;)
 (function_definition type: (type_identifier)
  declarator:
   (function_declarator declarator: (identifier)
    parameters:
     (parameter_list (
      (parameter_declaration type: (primitive_type))
      )))
  body: (compound_statement { }))
 #endif)
```
So we use last child node(i.e. "#endif") instead of 'alternative' node in this case.